### PR TITLE
feat: 🎸 brotli compression, esm and opt signatures

### DIFF
--- a/packages/stays-models/package.json
+++ b/packages/stays-models/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.6.0",
-    "ethers": "^5.6.6"
+    "ethers": "^5.6.6",
+    "zlib": "^1.0.5"
   },
   "devDependencies": {
     "@protobuf-ts/plugin": "^2.5.0",
@@ -43,7 +44,7 @@
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
     "@windingtree/videre-contracts": "^0.1.6",
-    "@windingtree/videre-sdk": "^0.4.0",
+    "@windingtree/videre-sdk": "^0.4.1",
     "chai": "^4.3.6",
     "chai-ethers": "^0.0.1",
     "eslint": "^8.15.0",
@@ -58,6 +59,5 @@
     "ts-node": "^10.7.0",
     "typechain": "^8.0.0",
     "typescript": "^4.6.4"
-  },
-  "type": "module"
+  }
 }

--- a/packages/stays-models/test/example.ts
+++ b/packages/stays-models/test/example.ts
@@ -1,12 +1,15 @@
 import { utils, Wallet } from "ethers";
 import { Exception, Facility, Item, ItemType, Space, SpaceTier } from "../src/proto/facility";
 import { ServiceProviderData } from "../src/proto/storage";
-import { utils as vUtils, eip712 } from "@windingtree/videre-sdk"
+import { brotliCompressSync } from "node:zlib"
 import { TypedDataDomain } from "@ethersproject/abstract-signer";
+
+import { utils as vUtils, eip712 } from "@windingtree/videre-sdk"
+import { SignedMessage } from "@windingtree/videre-sdk/dist/cjs/utils";
 
 
 async function main() {
-  const serviceProviderData: Omit<ServiceProviderData, "signature"> = {
+  const serviceProviderData: ServiceProviderData = {
     serviceProvider: utils.arrayify(utils.formatBytes32String('provider')),
     payload: Facility.toBinary(
       {
@@ -110,13 +113,15 @@ async function main() {
   const messageToUpload = await vUtils.createSignedMessage(
     domain,
     eip712.storage.ServiceProviderData,
-    serviceProviderData as ServiceProviderData,
+    serviceProviderData as ServiceProviderData & SignedMessage,
     new Wallet(utils.randomBytes(32))
   )
   
+  // test compression
+
   console.log(messageToUpload)
   console.log(`Signature: ${utils.hexlify(messageToUpload.signature)}`)
-  console.log(`Protobuf length: ${ServiceProviderData.toBinary(messageToUpload).length}`)
+  console.log(`Protobuf length: ${brotliCompressSync(ServiceProviderData.toBinary(messageToUpload)).length}`)
 }
 
 main()

--- a/packages/stays-models/tsconfig.json
+++ b/packages/stays-models/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2020",
-    "module": "es2020",
+    "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
     "moduleResolution": "node",
@@ -10,6 +10,5 @@
     "declaration": true
   },
   "include": [
-    "./src"
-, "test/example.ts"  ]
+    "./src"  ]
 }

--- a/packages/stays-models/yarn.lock
+++ b/packages/stays-models/yarn.lock
@@ -595,10 +595,10 @@
   dependencies:
     "@openzeppelin/contracts" "^4.5.0"
 
-"@windingtree/videre-sdk@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@windingtree/videre-sdk/-/videre-sdk-0.4.0.tgz#e03155b0db46a080324f48c7bfde88a39ff65588"
-  integrity sha512-dZi7abmTijvYjaL3MkTfKI6BtW7BmDr7BdERBr3HV6/NmRBX4QoYvGsRZW0OtoliFEaLhs6tdu7866t5m/5OVA==
+"@windingtree/videre-sdk@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@windingtree/videre-sdk/-/videre-sdk-0.4.1.tgz#5c6419e0f79bcf39a218893dd2166987be9612bb"
+  integrity sha512-dagKZ5sbmmK9OQwFLIOCy624J59gaOPQv7hFUsYcJj7yydIRZWDZYQ8pictq8QpIyD8soj0hl/QxnBVAoyEt5Q==
   dependencies:
     "@protobuf-ts/runtime" "^2.5.0"
     ethers "^5.6.5"
@@ -2610,3 +2610,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zlib@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/zlib/-/zlib-1.0.5.tgz#6e7c972fc371c645a6afb03ab14769def114fcc0"
+  integrity sha1-bnyXL8NxxkWmr7A6sUdp3vEU/MA=


### PR DESCRIPTION
This PR:

1. Demonstrates the use of `brotli` compression on the `ServiceProviderData` protobuf.
2. Utilises optional signatures for `ServiceProviderData` so that it may be sent by `lpms-cli` to `lpms-server` and be signed on the server.
3. Removes the `module` type from `package.json`, allowing for commonjs integration.