### PR TITLE
fix: 🐛 mkdir creates parents as well

### DIFF
--- a/packages/stays-models/package.json
+++ b/packages/stays-models/package.json
@@ -17,7 +17,7 @@
   "types": "./dist/cjs/index.d.ts",
   "scripts": {
     "typechain": "typechain --target ethers-v5 --glob './node_modules/@windingtree/videre-contracts/artifacts/**/*.json' --out-dir src/typechain",
-    "protoc:source": "rm -rf ./dist/proto && mkdir ./dist/proto && cp -R ./src/proto/*.proto ./dist/proto/",
+    "protoc:source": "rm -rf ./dist/proto && mkdir -p ./dist/proto && cp -R ./src/proto/*.proto ./dist/proto/",
     "protoc:local": "protoc --ts_out ./src/proto --proto_path ./src/proto ./src/proto/*.proto",
     "protoc:libs": "protoc --ts_out ./src/proto --proto_path ./node_modules/@windingtree/videre-sdk/dist/proto ./node_modules/@windingtree/videre-sdk/dist/proto/*.proto",
     "tsc": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",


### PR DESCRIPTION
This PR fixes the `prepublish` script for the `stays-models` such that the protobut dist directory's parents are created at the same time to avoid missing parent folders.