### PR TITLE
feat(stays-models): allow release to npm registry

### DIFF
--- a/packages/stays-models/package.json
+++ b/packages/stays-models/package.json
@@ -28,7 +28,7 @@
     "dist/"
   ],
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.6.0",


### PR DESCRIPTION
Allow stays-models to be pushed to npm registry