### PR TITLE
fix: stubstorage protobuf

### DIFF
--- a/packages/lpms-server/docs/STORAGE.md
+++ b/packages/lpms-server/docs/STORAGE.md
@@ -88,24 +88,14 @@ Level: `stubs`
 Description: Contains all the bookings (`stubs`) issued by this facility.
 
 Key: `stubId` (dynamic)
-Value: protobuf to wrap videre.Stub, stays-models.Ask, stays-models.Person
+Value: videre.stays.lpms.StubStorage
 Description: Contains all the data for the `stub` (booking). The EIP-712 hash of this `stub` should be equal to the `EIP-712` hash of the `stub` at `stubId` when looked up on chain.
-Notes: This meets the requirement (1)
+Notes: This meets the requirement (1) and (7)
 
 Key: `YYYY-MM-DD` (dynamic)
 Value: `string[]`
 Description: Contains a list of all stubs (bookings) that are on the specified date.
 Notes: This meets the requirement (2)
-
-#### pii
-
-Parent level: `facilityId` (dynamic)
-Level: `pii`
-
-Key: `stubId` (dynamic)
-Value: `videre.stays.lpms.person.Person`
-Description: Personal identifiable information, stored by `stubId`.
-Notes: Meets requirements (7)
 
 #### spaces
 

--- a/packages/stays-models/package.json
+++ b/packages/stays-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@windingtree/stays-models",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "win-stays videre data models",
   "author": "mfw78 <mfw78@protonmail.com>",
   "license": "MIT",

--- a/packages/stays-models/src/proto/lpms.proto
+++ b/packages/stays-models/src/proto/lpms.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package videre.stays.lpms;
 
 import "ask.proto";
+import "stub.proto";
+import "person.proto";
 
 enum Condition {
   LT = 0;
@@ -20,8 +22,17 @@ message Ratio {
 }
 
 // Store all parameters associated with a stub
+// This stores essentially two structs:
+// 1. The `Stub` struct which are the components that are fed to the smart contract
+//    as the parameters for a booking. Notably though, Stub.params is a hash, ie.
+//    it has no type, this is because it's industry agnostic. Therefore we now have:
+// 2. The `Ask` struct which constitute the parameters that the user asked for.
+//    this struct's contents are hashed and that becomes Stub.params.
 message StubStorage {
+  videre.type.Stub stub = 1;
   videre.stays.Ask params = 2;
+  // personal identifiable information kept with the booking (if any)
+  videre.type.Person pii = 3;
 }
 
 // Each 'space' represents a _room type_.


### PR DESCRIPTION
This PR:

1. Adds the `StubStorage` protobuf, which is designed to hold the industry-specific (ie. `stays`) params struct, and the generic stubs struct.
2. Updates the documentation to reflect where these protobufs will fit in.